### PR TITLE
tbb: Update hash in line with Intel's change of repo

### DIFF
--- a/Formula/tbb.rb
+++ b/Formula/tbb.rb
@@ -3,13 +3,13 @@ class Tbb < Formula
   homepage "https://www.threadingbuildingblocks.org/"
   url "https://github.com/01org/tbb/archive/2019_U3.tar.gz"
   version "2019_U3"
-  sha256 "b2244147bc8159cdd8f06a38afeb42f3237d3fc822555499d7ccfbd4b86f8ece"
+  sha256 "4cb6bde796ae056e7c29f31bfdc6cfd0cfe848925219e9c82a20f09158e81542"
   revision 2
+
+  depends_on "cmake" => :build
 
   # Patch for cmakeConfig, from spack
   patch :p0, :DATA
-
-  depends_on "cmake" => :build
 
   def install
     # In addition to patch, need an inreplace for tbb_root


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Linuxbrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Linuxbrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [x] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----

Hash is changed without version, as Intel's upstream repository has changed, thus new hashes for tarballs. Only audit not passing is `OS.mac?` which we allow here.