### PR TITLE
qt5-base: Update build for linux

### DIFF
--- a/Formula/qt5-base.rb
+++ b/Formula/qt5-base.rb
@@ -13,7 +13,6 @@ class Qt5Base < Formula
     depends_on "icu4c"
     depends_on "fontconfig"
     depends_on "freetype"
-    depends_on "zlib"
   end
 
   conflicts_with "qt5", :because => "Core homebrew ships a complete Qt5 install"
@@ -25,12 +24,18 @@ class Qt5Base < Formula
   end
 
   def install
+    unless OS.mac?
+      # Only way to get Qt to look for system GL/Xlibs
+      sys_pkgconf_path = Utils.popen_read("/usr/bin/pkg-config --variable pc_path pkg-config").chomp
+      ENV.append_path "PKG_CONFIG_PATH", "#{sys_pkgconf_path}"
+    end
+
     args = %W[
       -verbose
       -prefix #{prefix}
       -release
       -opensource -confirm-license
-      -system-zlib
+      -qt-zlib
       -qt-libpng
       -qt-libjpeg
       -qt-freetype
@@ -38,6 +43,7 @@ class Qt5Base < Formula
       -nomake tests
       -nomake examples
       -pkg-config
+      -no-openssl
       -no-avx
       -no-avx2
       -no-sql-mysql


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Linuxbrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Linuxbrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----

Preliminary fix for Linux build issues. Triaged to the newer Qt version's build system not being consistent with use of pkg-config for all build dependencies. Primary changes are:

- Force system pkg-config paths into build to reliably pick up system GL/X11 libs (which we use here).
- Use qt-zlib as no longer seems to find any reliable version from brew or system.
- Do not build QtNetwork with openssl. Not required for SuperNEMO, and Qt build is difficult to point to the right place.

A dependence on the CentOS7 `libxkbcommon-devel` package may exist (and the equivalent on Ubuntu), but requires additional testing in Docker.